### PR TITLE
Use module.main instead of module.parent

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ var highlight = module.exports = function (text, col) {
   }).join('')
 }
 
-if(!module.parent) {
+if(module === require.main) {
   console.log(
     highlight(require('fs').readFileSync(process.argv[2], 'utf8'))
   )


### PR DESCRIPTION
This patch replaces the `module.parent` check with the equivalent check using `module.main`. It [seems](http://nodejs.org/api/modules.html#modules_accessing_the_main_module) that this is the preferred way to do this in Node, and in Browserify, `module.parent` doesn't exist at all.
